### PR TITLE
Correct RightHand link mass and inertia values similar to LeftHand link 

### DIFF
--- a/humanSubject01/humanSubject01_48dof.urdf
+++ b/humanSubject01/humanSubject01_48dof.urdf
@@ -338,10 +338,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.0332"/>
+            <mass value="0.3732"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.083588           0" rpy="0 0 0" />
-            <inertia ixx="0.0025391" iyy="0.0012022" izz="0.0034758" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.00091713" iyy="0.00043425" izz="0.0012555" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject01/humanSubject01_66dof-bkp.urdf
+++ b/humanSubject01/humanSubject01_66dof-bkp.urdf
@@ -409,10 +409,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.0332"/>
+            <mass value="0.3732"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.083588           0" rpy="0 0 0" />
-            <inertia ixx="0.0025391" iyy="0.0012022" izz="0.0034758" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.00091713" iyy="0.00043425" izz="0.0012555" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject01/humanSubject01_66dof.urdf
+++ b/humanSubject01/humanSubject01_66dof.urdf
@@ -394,10 +394,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.0332"/>
+            <mass value="0.3732"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.083588           0" rpy="0 0 0" />
-            <inertia ixx="0.0025391" iyy="0.0012022" izz="0.0034758" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.00091713" iyy="0.00043425" izz="0.0012555" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject01/humanSubject01_66dof_colored.urdf
+++ b/humanSubject01/humanSubject01_66dof_colored.urdf
@@ -454,10 +454,10 @@
 	</link>
 	<link name="RightHand">
 		<inertial>
-			<mass value="1.0332"/>
+			<mass value="0.3732"/>
 			<!--COM origin wrt jRightWrist-->
 			<origin xyz="0   -0.083588           0" rpy="0 0 0" />
-			<inertia ixx="0.0025391" iyy="0.0012022" izz="0.0034758" ixy="0" ixz="0" iyz="0"/>
+			<inertia ixx="0.00091713" iyy="0.00043425" izz="0.0012555" ixy="0" ixz="0" iyz="0"/>
 		</inertial>
 
 		<visual>

--- a/humanSubject02/humanSubject02_48dof.urdf
+++ b/humanSubject02/humanSubject02_48dof.urdf
@@ -338,10 +338,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.1364"/>
+            <mass value="0.4764"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.086009           0" rpy="0 0 0" />
-            <inertia ixx="0.0029539" iyy="0.0013971" izz="0.0040476" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.0012383" iyy="0.00058568" izz="0.0016968" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject02/humanSubject02_66dof.urdf
+++ b/humanSubject02/humanSubject02_66dof.urdf
@@ -394,10 +394,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.1364"/>
+            <mass value="0.4764"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.086009           0" rpy="0 0 0" />
-            <inertia ixx="0.0029539" iyy="0.0013971" izz="0.0040476" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.0012383" iyy="0.00058568" izz="0.0016968" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject03/humanSubject03_48dof.urdf
+++ b/humanSubject03/humanSubject03_48dof.urdf
@@ -338,10 +338,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.1124"/>
+            <mass value="0.4524"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.096206           0" rpy="0 0 0" />
-            <inertia ixx="0.0036219" iyy="0.0017152" izz="0.0049573" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.001473" iyy="0.00069756" izz="0.0020161" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject03/humanSubject03_66dof.urdf
+++ b/humanSubject03/humanSubject03_66dof.urdf
@@ -424,10 +424,10 @@
 	</link>
 	<link name="RightHand">
 		<inertial>
-			<mass value="1.1124"/>
+			<mass value="0.4524"/>
 			<!--COM origin wrt jRightWrist-->
 			<origin xyz="0   -0.096206           0" rpy="0 0 0" />
-			<inertia ixx="0.0036219" iyy="0.0017152" izz="0.0049573" ixy="0" ixz="0" iyz="0"/>
+			<inertia ixx="0.001473" iyy="0.00069756" izz="0.0020161" ixy="0" ixz="0" iyz="0"/>
 		</inertial>
 
 		<visual>

--- a/humanSubject04/humanSubject04_48dof.urdf
+++ b/humanSubject04/humanSubject04_48dof.urdf
@@ -338,10 +338,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.0962"/>
+            <mass value="0.4362"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0    -0.10039           0" rpy="0 0 0" />
-            <inertia ixx="0.0038879" iyy="0.0018422" izz="0.0053188" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.0015471" iyy="0.00073303" izz="0.0021165" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject04/humanSubject04_66dof.urdf
+++ b/humanSubject04/humanSubject04_66dof.urdf
@@ -394,10 +394,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.0962"/>
+            <mass value="0.4362"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0    -0.10039           0" rpy="0 0 0" />
-            <inertia ixx="0.0038879" iyy="0.0018422" izz="0.0053188" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.0015471" iyy="0.00073303" izz="0.0021165" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject05/humanSubject05_48dof.urdf
+++ b/humanSubject05/humanSubject05_48dof.urdf
@@ -338,10 +338,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="0.99"/>
+            <mass value="0.33"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.085441           0" rpy="0 0 0" />
-            <inertia ixx="0.002542" iyy="0.0012036" izz="0.0034797" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.00084732" iyy="0.0004012" izz="0.0011599" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject05/humanSubject05_66dof.urdf
+++ b/humanSubject05/humanSubject05_66dof.urdf
@@ -454,10 +454,10 @@
 	</link>
 	<link name="RightHand">
 		<inertial>
-			<mass value="0.99"/>
+			<mass value="0.33"/>
 			<!--COM origin wrt jRightWrist-->
 			<origin xyz="0   -0.085441           0" rpy="0 0 0" />
-			<inertia ixx="0.002542" iyy="0.0012036" izz="0.0034797" ixy="0" ixz="0" iyz="0"/>
+			<inertia ixx="0.00084732" iyy="0.0004012" izz="0.0011599" ixy="0" ixz="0" iyz="0"/>
 		</inertial>
 
 		<visual>

--- a/humanSubject06/humanSubject06_48dof.urdf
+++ b/humanSubject06/humanSubject06_48dof.urdf
@@ -338,10 +338,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.0872"/>
+            <mass value="0.4272"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.090968           0" rpy="0 0 0" />
-            <inertia ixx="0.0031623" iyy="0.0014962" izz="0.0043318" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.0012426" iyy="0.00058792" izz="0.0017021" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject06/humanSubject06_66dof.urdf
+++ b/humanSubject06/humanSubject06_66dof.urdf
@@ -394,10 +394,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.0872"/>
+            <mass value="0.4272"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.090968           0" rpy="0 0 0" />
-            <inertia ixx="0.0031623" iyy="0.0014962" izz="0.0043318" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.0012426" iyy="0.00058792" izz="0.0017021" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject07/humanSubject07_48dof.urdf
+++ b/humanSubject07/humanSubject07_48dof.urdf
@@ -338,10 +338,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.1334"/>
+            <mass value="0.4734"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.096871           0" rpy="0 0 0" />
-            <inertia ixx="0.0037418" iyy="0.0017721" izz="0.005121" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.0015629" iyy="0.00074019" izz="0.0021389" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject07/humanSubject07_66dof.urdf
+++ b/humanSubject07/humanSubject07_66dof.urdf
@@ -394,10 +394,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="1.1334"/>
+            <mass value="0.4734"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.096871           0" rpy="0 0 0" />
-            <inertia ixx="0.0037418" iyy="0.0017721" izz="0.005121" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.0015629" iyy="0.00074019" izz="0.0021389" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject08/humanSubject08_48dof.urdf
+++ b/humanSubject08/humanSubject08_48dof.urdf
@@ -338,10 +338,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="0.9912"/>
+            <mass value="0.3312"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.086727           0" rpy="0 0 0" />
-            <inertia ixx="0.0026232" iyy="0.0012426" izz="0.0035897" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.00087653" iyy="0.0004152" izz="0.0011995" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>

--- a/humanSubject08/humanSubject08_66dof.urdf
+++ b/humanSubject08/humanSubject08_66dof.urdf
@@ -338,10 +338,10 @@
     </link>
 	<link name="RightHand">
         <inertial>
-            <mass value="0.9912"/>
+            <mass value="0.3312"/>
 			<!--COM origin wrt jRightWrist-->
             <origin xyz="0   -0.086727           0" rpy="0 0 0" />
-            <inertia ixx="0.0026232" iyy="0.0012426" izz="0.0035897" ixy="0" ixz="0" iyz="0"/>
+            <inertia ixx="0.00087653" iyy="0.0004152" izz="0.0011995" ixy="0" ixz="0" iyz="0"/>
         </inertial>
 
         <visual>


### PR DESCRIPTION
This PR addresses the issue https://github.com/robotology/human-gazebo/issues/12
It corrects the mass and inertial values of the `RightHand` link to be similar to `LeftHand` link.

NOTE: The `RightHand` mass and inertial values seem to be a **3** times that of the `LeftHand` values. 

@claudia-lat @lrapetti @DanielePucci 