### PR TITLE
Change link colors to gray

### DIFF
--- a/humanSubject01/humanSubject01_48dof.urdf
+++ b/humanSubject01/humanSubject01_48dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 48 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.13815     0.24914    0.097469"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -51,6 +57,7 @@
             <geometry>
                 <box size="0.13815     0.16323    0.095104"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -82,6 +89,7 @@
             <geometry>
                 <box size="0.13815     0.16323    0.085916"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -113,6 +121,7 @@
             <geometry>
                 <box size="0.13815     0.16323    0.085916"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -151,6 +160,7 @@
             <geometry>
                 <box size="0.13457    0.052626     0.11975"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -190,6 +200,7 @@
             <geometry>
 		<cylinder length="0.089252" radius="0.014205"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -221,6 +232,7 @@
             <geometry>
                 <sphere radius="0.089005"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -247,6 +259,7 @@
             <geometry>
                 <cylinder length="0.13047" radius="0.023574"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -286,6 +299,7 @@
             <geometry>
                 <cylinder length="0.26994" radius="0.029449"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -318,6 +332,7 @@
             <geometry>
                 <cylinder length="0.22247" radius="0.019633"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -350,6 +365,7 @@
             <geometry>
                 <box size="0.11145     0.16718    0.039266"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -376,6 +392,7 @@
             <geometry>
                 <cylinder length="0.13047" radius="0.023574"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -415,6 +432,7 @@
             <geometry>
                 <cylinder length="0.26994" radius="0.029449"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -447,6 +465,7 @@
             <geometry>
                 <cylinder length="0.22247" radius="0.019633"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -479,6 +498,7 @@
             <geometry>
                 <box size="0.11145     0.16718    0.039266"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -519,6 +539,7 @@
             <geometry>
                 <cylinder length="0.44898" radius="0.0565"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -551,6 +572,7 @@
             <geometry>
                 <cylinder length="0.40608" radius="0.037388"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -590,6 +612,7 @@
             <geometry>
                 <box size="0.17983    0.074775    0.078509"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -615,6 +638,7 @@
             <geometry>
                 <box size="0.060173    0.074775    0.014191"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -654,6 +678,7 @@
             <geometry>
                 <cylinder length="0.44898" radius="0.0565"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -686,6 +711,7 @@
             <geometry>
 		<cylinder length="0.40608" radius="0.037388"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -725,6 +751,7 @@
             <geometry>
                 <box size="0.17983    0.074775    0.078509"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -750,6 +777,7 @@
             <geometry>
                 <box size="0.060173    0.074775    0.014191"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject01/humanSubject01_66dof.urdf
+++ b/humanSubject01/humanSubject01_66dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 66 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.13815     0.24914    0.097469"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -58,6 +64,7 @@
             <geometry>
                 <box size="0.13815     0.16323    0.095104"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -96,6 +103,7 @@
             <geometry>
                 <box size="0.13815     0.16323    0.085916"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -134,6 +142,7 @@
             <geometry>
                 <box size="0.13815     0.16323    0.085916"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -172,6 +181,7 @@
             <geometry>
                 <box size="0.13457    0.052626     0.11975"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -211,6 +221,7 @@
             <geometry>
 		<cylinder length="0.089252" radius="0.014205"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -249,6 +260,7 @@
             <geometry>
                 <sphere radius="0.089005"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -289,6 +301,7 @@
             <geometry>
                 <cylinder length="0.13047" radius="0.023574"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -328,6 +341,7 @@
             <geometry>
                 <cylinder length="0.26994" radius="0.029449"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -367,6 +381,7 @@
             <geometry>
                 <cylinder length="0.22247" radius="0.019633"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -406,6 +421,7 @@
             <geometry>
                 <box size="0.11145     0.16718    0.039266"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -446,6 +462,7 @@
             <geometry>
                 <cylinder length="0.13047" radius="0.023574"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -485,6 +502,7 @@
             <geometry>
                 <cylinder length="0.26994" radius="0.029449"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -524,6 +542,7 @@
             <geometry>
                 <cylinder length="0.22247" radius="0.019633"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -563,6 +582,7 @@
             <geometry>
                 <box size="0.11145     0.16718    0.039266"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -603,6 +623,7 @@
             <geometry>
                 <cylinder length="0.44898" radius="0.0565"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -642,6 +663,7 @@
             <geometry>
                 <cylinder length="0.40608" radius="0.037388"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -681,6 +703,7 @@
             <geometry>
                 <box size="0.17983    0.074775    0.078509"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -720,6 +743,7 @@
             <geometry>
                 <box size="0.060173    0.074775    0.014191"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -759,6 +783,7 @@
             <geometry>
                 <cylinder length="0.44898" radius="0.0565"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -798,6 +823,7 @@
             <geometry>
 		<cylinder length="0.40608" radius="0.037388"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -837,6 +863,7 @@
             <geometry>
                 <box size="0.17983    0.074775    0.078509"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -876,6 +903,7 @@
             <geometry>
                 <box size="0.060173    0.074775    0.014191"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject02/humanSubject02_48dof.urdf
+++ b/humanSubject02/humanSubject02_48dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 48 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.17519     0.32675     0.11973"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -51,6 +57,7 @@
             <geometry>
                 <box size="0.17519     0.20699     0.08793"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -82,6 +89,7 @@
             <geometry>
                 <box size="0.17519     0.20699    0.079417"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -113,6 +121,7 @@
             <geometry>
                 <box size="0.17519     0.20699    0.079417"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -151,6 +160,7 @@
             <geometry>
                 <box size="0.13327    0.055172     0.11227"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -190,6 +200,7 @@
             <geometry>
 		<cylinder length="0.10427" radius="0.016051"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -221,6 +232,7 @@
             <geometry>
                 <sphere radius="0.11223"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -247,6 +259,7 @@
             <geometry>
                 <cylinder length="0.14666" radius="0.026313"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -286,6 +299,7 @@
             <geometry>
                 <cylinder length="0.27379" radius="0.030014"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -318,6 +332,7 @@
             <geometry>
                 <cylinder length="0.22718" radius="0.020009"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -350,6 +365,7 @@
             <geometry>
                 <box size="0.11468     0.17202    0.040019"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -376,6 +392,7 @@
             <geometry>
                 <cylinder length="0.14666" radius="0.026313"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -415,6 +432,7 @@
             <geometry>
                 <cylinder length="0.27379" radius="0.030014"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -447,6 +465,7 @@
             <geometry>
                 <cylinder length="0.22718" radius="0.020009"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -479,6 +498,7 @@
             <geometry>
                 <box size="0.11468     0.17202    0.040019"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -519,6 +539,7 @@
             <geometry>
                 <cylinder length="0.47802" radius="0.060305"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -551,6 +572,7 @@
             <geometry>
                 <cylinder length="0.40179" radius="0.037143"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -590,6 +612,7 @@
             <geometry>
                 <box size="0.18999    0.074286    0.078097"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -615,6 +638,7 @@
             <geometry>
                 <box size="0.070006    0.074286    0.016026"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -654,6 +678,7 @@
             <geometry>
                 <cylinder length="0.47802" radius="0.060305"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -686,6 +711,7 @@
             <geometry>
 		<cylinder length="0.40179" radius="0.037143"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -725,6 +751,7 @@
             <geometry>
                 <box size="0.18999    0.074286    0.078097"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -750,6 +777,7 @@
             <geometry>
                 <box size="0.070006    0.074286    0.016026"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject02/humanSubject02_66dof.urdf
+++ b/humanSubject02/humanSubject02_66dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 66 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.17519     0.32675     0.11973"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -58,6 +64,7 @@
             <geometry>
                 <box size="0.17519     0.20699     0.08793"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -96,6 +103,7 @@
             <geometry>
                 <box size="0.17519     0.20699    0.079417"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -134,6 +142,7 @@
             <geometry>
                 <box size="0.17519     0.20699    0.079417"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -172,6 +181,7 @@
             <geometry>
                 <box size="0.13327    0.055172     0.11227"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -211,6 +221,7 @@
             <geometry>
 		<cylinder length="0.10427" radius="0.016051"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -249,6 +260,7 @@
             <geometry>
                 <sphere radius="0.11223"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -289,6 +301,7 @@
             <geometry>
                 <cylinder length="0.14666" radius="0.026313"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -328,6 +341,7 @@
             <geometry>
                 <cylinder length="0.27379" radius="0.030014"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -367,6 +381,7 @@
             <geometry>
                 <cylinder length="0.22718" radius="0.020009"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -406,6 +421,7 @@
             <geometry>
                 <box size="0.11468     0.17202    0.040019"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -446,6 +462,7 @@
             <geometry>
                 <cylinder length="0.14666" radius="0.026313"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -485,6 +502,7 @@
             <geometry>
                 <cylinder length="0.27379" radius="0.030014"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -524,6 +542,7 @@
             <geometry>
                 <cylinder length="0.22718" radius="0.020009"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -563,6 +582,7 @@
             <geometry>
                 <box size="0.11468     0.17202    0.040019"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -603,6 +623,7 @@
             <geometry>
                 <cylinder length="0.47802" radius="0.060305"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -642,6 +663,7 @@
             <geometry>
                 <cylinder length="0.40179" radius="0.037143"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -681,6 +703,7 @@
             <geometry>
                 <box size="0.18999    0.074286    0.078097"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -720,6 +743,7 @@
             <geometry>
                 <box size="0.070006    0.074286    0.016026"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -759,6 +783,7 @@
             <geometry>
                 <cylinder length="0.47802" radius="0.060305"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -798,6 +823,7 @@
             <geometry>
 		<cylinder length="0.40179" radius="0.037143"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -837,6 +863,7 @@
             <geometry>
                 <box size="0.18999    0.074286    0.078097"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -876,6 +903,7 @@
             <geometry>
                 <box size="0.070006    0.074286    0.016026"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject03/humanSubject03_48dof.urdf
+++ b/humanSubject03/humanSubject03_48dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 48 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.1529      0.2785     0.10227"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -51,6 +57,7 @@
             <geometry>
                 <box size="0.1529     0.18065    0.090247"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -82,6 +89,7 @@
             <geometry>
                 <box size="0.1529     0.18065    0.081508"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -113,6 +121,7 @@
             <geometry>
                 <box size="0.1529     0.18065    0.081508"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -151,6 +160,7 @@
             <geometry>
                 <box size="0.13947    0.059444     0.11632"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -190,6 +200,7 @@
             <geometry>
 		<cylinder length="0.096529" radius="0.015541"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -221,6 +232,7 @@
             <geometry>
                 <sphere radius="0.099278"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -247,6 +259,7 @@
             <geometry>
                 <cylinder length="0.15959" radius="0.028244"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -286,6 +299,7 @@
             <geometry>
                 <cylinder length="0.31253" radius="0.033946"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -318,6 +332,7 @@
             <geometry>
                 <cylinder length="0.25648" radius="0.022631"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -350,6 +365,7 @@
             <geometry>
                 <box size="0.12827     0.19241    0.045261"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -376,6 +392,7 @@
             <geometry>
                 <cylinder length="0.15959" radius="0.028244"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -415,6 +432,7 @@
             <geometry>
                 <cylinder length="0.31253" radius="0.033946"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -447,6 +465,7 @@
             <geometry>
                 <cylinder length="0.25648" radius="0.022631"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -479,6 +498,7 @@
             <geometry>
                 <box size="0.12827     0.19241    0.045261"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -519,6 +539,7 @@
             <geometry>
                 <cylinder length="0.46162" radius="0.058441"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -551,6 +572,7 @@
             <geometry>
                 <cylinder length="0.49826" radius="0.045604"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -590,6 +612,7 @@
             <geometry>
                 <box size="0.19526    0.091208     0.07901"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -615,6 +638,7 @@
             <geometry>
                 <box size="0.074739    0.091208    0.017037"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -654,6 +678,7 @@
             <geometry>
                 <cylinder length="0.46162" radius="0.058441"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -686,6 +711,7 @@
             <geometry>
 		<cylinder length="0.49826" radius="0.045604"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -725,6 +751,7 @@
             <geometry>
                 <box size="0.19526    0.091208     0.07901"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -750,6 +777,7 @@
             <geometry>
                 <box size="0.074739    0.091208    0.017037"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject03/humanSubject03_66dof.urdf
+++ b/humanSubject03/humanSubject03_66dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 66 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 	<!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
 	<!--LINKS-->
 	<!--Link base (1)-->
@@ -18,9 +23,7 @@
 			<geometry>
 				<box size="0.1529      0.2785     0.10227"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -61,9 +64,7 @@
 			<geometry>
 				<box size="0.1529     0.18065    0.090247"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -102,9 +103,7 @@
 			<geometry>
 				<box size="0.1529     0.18065    0.081508"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -143,9 +142,7 @@
 			<geometry>
 				<box size="0.1529     0.18065    0.081508"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -184,9 +181,7 @@
 			<geometry>
 				<box size="0.13947    0.059444     0.11632"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -226,9 +221,7 @@
 			<geometry>
 				<cylinder length="0.096529" radius="0.015541"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -267,9 +260,7 @@
 			<geometry>
 				<sphere radius="0.099278"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -310,9 +301,7 @@
 			<geometry>
 				<cylinder length="0.15959" radius="0.028244"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -352,9 +341,7 @@
 			<geometry>
 				<cylinder length="0.31253" radius="0.033946"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -394,9 +381,7 @@
 			<geometry>
 				<cylinder length="0.25648" radius="0.022631"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -436,9 +421,7 @@
 			<geometry>
 				<box size="0.12827     0.19241    0.045261"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -479,9 +462,7 @@
 			<geometry>
 				<cylinder length="0.15959" radius="0.028244"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -521,9 +502,7 @@
 			<geometry>
 				<cylinder length="0.31253" radius="0.033946"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -563,9 +542,7 @@
 			<geometry>
 				<cylinder length="0.25648" radius="0.022631"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -605,9 +582,7 @@
 			<geometry>
 				<box size="0.12827     0.19241    0.045261"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -648,9 +623,7 @@
 			<geometry>
 				<cylinder length="0.46162" radius="0.058441"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -690,9 +663,7 @@
 			<geometry>
 				<cylinder length="0.49826" radius="0.045604"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -732,9 +703,7 @@
 			<geometry>
 				<box size="0.19526    0.091208     0.07901"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -774,9 +743,7 @@
 			<geometry>
 				<box size="0.074739    0.091208    0.017037"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -816,9 +783,7 @@
 			<geometry>
 				<cylinder length="0.46162" radius="0.058441"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -858,9 +823,7 @@
 			<geometry>
 				<cylinder length="0.49826" radius="0.045604"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -900,9 +863,7 @@
 			<geometry>
 				<box size="0.19526    0.091208     0.07901"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -942,9 +903,7 @@
 			<geometry>
 				<box size="0.074739    0.091208    0.017037"/>
 			</geometry>
-			<material name="red">
-				<color rgba="1.0 0 0 1"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>

--- a/humanSubject04/humanSubject04_48dof.urdf
+++ b/humanSubject04/humanSubject04_48dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 48 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.15816     0.28838     0.10665"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -51,6 +57,7 @@
             <geometry>
                 <box size="0.15816     0.18687    0.093964"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -82,6 +89,7 @@
             <geometry>
                 <box size="0.15816     0.18687     0.08487"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -113,6 +121,7 @@
             <geometry>
                 <box size="0.15816     0.18687     0.08487"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -151,6 +160,7 @@
             <geometry>
                 <box size="0.14221    0.058696     0.11958"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -190,6 +200,7 @@
             <geometry>
 		<cylinder length="0.09767" radius="0.015762"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -221,6 +232,7 @@
             <geometry>
                 <sphere radius="0.099558"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -247,6 +259,7 @@
             <geometry>
                 <cylinder length="0.15754" radius="0.027944"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -286,6 +299,7 @@
             <geometry>
                 <cylinder length="0.32874" radius="0.035581"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -318,6 +332,7 @@
             <geometry>
                 <cylinder length="0.26863" radius="0.023721"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -350,6 +365,7 @@
             <geometry>
                 <box size="0.13385     0.20077    0.047441"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -376,6 +392,7 @@
             <geometry>
                 <cylinder length="0.15754" radius="0.027944"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -415,6 +432,7 @@
             <geometry>
                 <cylinder length="0.32874" radius="0.035581"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -447,6 +465,7 @@
             <geometry>
                 <cylinder length="0.26863" radius="0.023721"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -479,6 +498,7 @@
             <geometry>
                 <box size="0.13385     0.20077    0.047441"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -519,6 +539,7 @@
             <geometry>
                 <cylinder length="0.48159" radius="0.060881"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -551,6 +572,7 @@
             <geometry>
                 <cylinder length="0.47962" radius="0.044033"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -590,6 +612,7 @@
             <geometry>
                 <box size="0.18849    0.088065    0.077914"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -615,6 +638,7 @@
             <geometry>
                 <box size="0.071513    0.088065    0.016626"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -654,6 +678,7 @@
             <geometry>
                 <cylinder length="0.48159" radius="0.060881"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -686,6 +711,7 @@
             <geometry>
 		<cylinder length="0.47962" radius="0.044033"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -725,6 +751,7 @@
             <geometry>
                 <box size="0.18849    0.088065    0.077914"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -750,6 +777,7 @@
             <geometry>
                 <box size="0.071513    0.088065    0.016626"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject04/humanSubject04_66dof.urdf
+++ b/humanSubject04/humanSubject04_66dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 66 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.15816     0.28838     0.10665"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -58,6 +64,7 @@
             <geometry>
                 <box size="0.15816     0.18687    0.093964"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -96,6 +103,7 @@
             <geometry>
                 <box size="0.15816     0.18687     0.08487"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -134,6 +142,7 @@
             <geometry>
                 <box size="0.15816     0.18687     0.08487"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -172,6 +181,7 @@
             <geometry>
                 <box size="0.14221    0.058696     0.11958"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -211,6 +221,7 @@
             <geometry>
 		<cylinder length="0.09767" radius="0.015762"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -249,6 +260,7 @@
             <geometry>
                 <sphere radius="0.099558"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -289,6 +301,7 @@
             <geometry>
                 <cylinder length="0.15754" radius="0.027944"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -328,6 +341,7 @@
             <geometry>
                 <cylinder length="0.32874" radius="0.035581"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -367,6 +381,7 @@
             <geometry>
                 <cylinder length="0.26863" radius="0.023721"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -406,6 +421,7 @@
             <geometry>
                 <box size="0.13385     0.20077    0.047441"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -446,6 +462,7 @@
             <geometry>
                 <cylinder length="0.15754" radius="0.027944"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -485,6 +502,7 @@
             <geometry>
                 <cylinder length="0.32874" radius="0.035581"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -524,6 +542,7 @@
             <geometry>
                 <cylinder length="0.26863" radius="0.023721"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -563,6 +582,7 @@
             <geometry>
                 <box size="0.13385     0.20077    0.047441"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -603,6 +623,7 @@
             <geometry>
                 <cylinder length="0.48159" radius="0.060881"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -642,6 +663,7 @@
             <geometry>
                 <cylinder length="0.47962" radius="0.044033"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -681,6 +703,7 @@
             <geometry>
                 <box size="0.18849    0.088065    0.077914"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -720,6 +743,7 @@
             <geometry>
                 <box size="0.071513    0.088065    0.016626"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -759,6 +783,7 @@
             <geometry>
                 <cylinder length="0.48159" radius="0.060881"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -798,6 +823,7 @@
             <geometry>
 		<cylinder length="0.47962" radius="0.044033"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -837,6 +863,7 @@
             <geometry>
                 <box size="0.18849    0.088065    0.077914"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -876,6 +903,7 @@
             <geometry>
                 <box size="0.071513    0.088065    0.016626"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject05/humanSubject05_48dof.urdf
+++ b/humanSubject05/humanSubject05_48dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 48 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.13695     0.24878    0.091304"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -51,6 +57,7 @@
             <geometry>
                 <box size="0.13695      0.1618    0.081662"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -82,6 +89,7 @@
             <geometry>
                 <box size="0.13695      0.1618    0.073749"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -113,6 +121,7 @@
             <geometry>
                 <box size="0.13695      0.1618    0.073749"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -151,6 +160,7 @@
             <geometry>
                 <box size="0.12543    0.051924     0.10425"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -190,6 +200,7 @@
             <geometry>
 		<cylinder length="0.087412" radius="0.014099"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -221,6 +232,7 @@
             <geometry>
                 <sphere radius="0.089927"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -247,6 +259,7 @@
             <geometry>
                 <cylinder length="0.14091" radius="0.025164"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -286,6 +299,7 @@
             <geometry>
                 <cylinder length="0.27611" radius="0.030104"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -318,6 +332,7 @@
             <geometry>
                 <cylinder length="0.22743" radius="0.020069"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -350,6 +365,7 @@
             <geometry>
                 <box size="0.11392     0.17088    0.040138"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -376,6 +392,7 @@
             <geometry>
                 <cylinder length="0.14091" radius="0.025164"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -415,6 +432,7 @@
             <geometry>
                 <cylinder length="0.27611" radius="0.030104"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -447,6 +465,7 @@
             <geometry>
                 <cylinder length="0.22743" radius="0.020069"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -479,6 +498,7 @@
             <geometry>
                 <box size="0.11392     0.17088    0.040138"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -519,6 +539,7 @@
             <geometry>
                 <cylinder length="0.4767" radius="0.060101"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -551,6 +572,7 @@
             <geometry>
                 <cylinder length="0.44087" radius="0.040434"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -590,6 +612,7 @@
             <geometry>
                 <box size="0.17852    0.080869    0.075737"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -615,6 +638,7 @@
             <geometry>
                 <box size="0.061481    0.080869    0.014482"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -654,6 +678,7 @@
             <geometry>
                 <cylinder length="0.4767" radius="0.060101"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -686,6 +711,7 @@
             <geometry>
 		<cylinder length="0.44087" radius="0.040434"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -725,6 +751,7 @@
             <geometry>
                 <box size="0.17852    0.080869    0.075737"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -750,6 +777,7 @@
             <geometry>
                 <box size="0.061481    0.080869    0.014482"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject05/humanSubject05_66dof.urdf
+++ b/humanSubject05/humanSubject05_66dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 66 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 	<!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
 	<!--LINKS-->
 	<!--Link base (1)-->
@@ -18,9 +23,7 @@
 			<geometry>
 				<box size="0.13695     0.24878    0.091304"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -29,9 +32,6 @@
 			<geometry>
 				<box size="0.13695     0.24878    0.091304"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -64,9 +64,7 @@
 			<geometry>
 				<box size="0.13695      0.1618    0.081662"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -75,9 +73,6 @@
 			<geometry>
 				<box size="0.13695      0.1618    0.081662"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 	</link>
 	<link name="L3_f1">
@@ -108,9 +103,7 @@
 			<geometry>
 				<box size="0.13695      0.1618    0.073749"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -119,9 +112,6 @@
 			<geometry>
 				<box size="0.13695      0.1618    0.073749"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 	</link>
 	<link name="T12_f1">
@@ -152,9 +142,7 @@
 			<geometry>
 				<box size="0.13695      0.1618    0.073749"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -163,9 +151,6 @@
 			<geometry>
 				<box size="0.13695      0.1618    0.073749"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 	</link>
 	<link name="T8_f1">
@@ -196,9 +181,7 @@
 			<geometry>
 				<box size="0.12543    0.051924     0.10425"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -207,9 +190,6 @@
 			<geometry>
 				<box size="0.12543    0.051924     0.10425"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -241,9 +221,7 @@
 			<geometry>
 				<cylinder length="0.087412" radius="0.014099"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -252,9 +230,6 @@
 			<geometry>
 				<cylinder length="0.087412" radius="0.014099"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 	</link>
 	<link name="Head_f1">
@@ -285,9 +260,7 @@
 			<geometry>
 				<sphere radius="0.089927"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -296,9 +269,6 @@
 			<geometry>
 				<sphere radius="0.089927"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -331,9 +301,7 @@
 			<geometry>
 				<cylinder length="0.14091" radius="0.025164"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -342,9 +310,6 @@
 			<geometry>
 				<cylinder length="0.14091" radius="0.025164"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -376,9 +341,7 @@
 			<geometry>
 				<cylinder length="0.27611" radius="0.030104"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -387,9 +350,6 @@
 			<geometry>
 				<cylinder length="0.27611" radius="0.030104"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -421,9 +381,7 @@
 			<geometry>
 				<cylinder length="0.22743" radius="0.020069"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -432,9 +390,6 @@
 			<geometry>
 				<cylinder length="0.22743" radius="0.020069"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -466,9 +421,7 @@
 			<geometry>
 				<box size="0.11392     0.17088    0.040138"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -477,9 +430,6 @@
 			<geometry>
 				<box size="0.11392     0.17088    0.040138"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -512,9 +462,7 @@
 			<geometry>
 				<cylinder length="0.14091" radius="0.025164"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -523,9 +471,6 @@
 			<geometry>
 				<cylinder length="0.14091" radius="0.025164"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -557,9 +502,7 @@
 			<geometry>
 				<cylinder length="0.27611" radius="0.030104"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -568,9 +511,6 @@
 			<geometry>
 				<cylinder length="0.27611" radius="0.030104"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -602,9 +542,7 @@
 			<geometry>
 				<cylinder length="0.22743" radius="0.020069"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -613,9 +551,6 @@
 			<geometry>
 				<cylinder length="0.22743" radius="0.020069"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -647,9 +582,7 @@
 			<geometry>
 				<box size="0.11392     0.17088    0.040138"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -658,9 +591,6 @@
 			<geometry>
 				<box size="0.11392     0.17088    0.040138"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -693,9 +623,7 @@
 			<geometry>
 				<cylinder length="0.4767" radius="0.060101"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -704,9 +632,6 @@
 			<geometry>
 				<cylinder length="0.4767" radius="0.060101"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -738,9 +663,7 @@
 			<geometry>
 				<cylinder length="0.44087" radius="0.040434"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -749,9 +672,6 @@
 			<geometry>
 				<cylinder length="0.44087" radius="0.040434"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -783,9 +703,7 @@
 			<geometry>
 				<box size="0.17852    0.080869    0.075737"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -794,9 +712,6 @@
 			<geometry>
 				<box size="0.17852    0.080869    0.075737"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -828,9 +743,7 @@
 			<geometry>
 				<box size="0.061481    0.080869    0.014482"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -839,9 +752,6 @@
 			<geometry>
 				<box size="0.061481    0.080869    0.014482"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 	</link>
 	<!--Chain from (20) to (23)-->
@@ -873,9 +783,7 @@
 			<geometry>
 				<cylinder length="0.4767" radius="0.060101"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -884,9 +792,6 @@
 			<geometry>
 				<cylinder length="0.4767" radius="0.060101"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -918,9 +823,7 @@
 			<geometry>
 				<cylinder length="0.44087" radius="0.040434"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -929,9 +832,6 @@
 			<geometry>
 				<cylinder length="0.44087" radius="0.040434"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -963,9 +863,7 @@
 			<geometry>
 				<box size="0.17852    0.080869    0.075737"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -974,9 +872,6 @@
 			<geometry>
 				<box size="0.17852    0.080869    0.075737"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 
 	</link>
@@ -1008,9 +903,7 @@
 			<geometry>
 				<box size="0.061481    0.080869    0.014482"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
+			<material name="color"/>
 		</visual>
 
 		<collision>
@@ -1019,9 +912,6 @@
 			<geometry>
 				<box size="0.061481    0.080869    0.014482"/>
 			</geometry>
-			<material name="Cyan">
-				<color rgba="1 0.5 0.6 0.5"/>
-			</material>
 		</collision>
 	</link>
 

--- a/humanSubject06/humanSubject06_48dof.urdf
+++ b/humanSubject06/humanSubject06_48dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 48 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.16655     0.30753      0.1127"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -51,6 +57,7 @@
             <geometry>
                 <box size="0.16655     0.19678    0.089762"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -82,6 +89,7 @@
             <geometry>
                 <box size="0.16655     0.19678    0.081071"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -113,6 +121,7 @@
             <geometry>
                 <box size="0.16655     0.19678    0.081071"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -151,6 +160,7 @@
             <geometry>
                 <box size="0.13852    0.059426     0.11612"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -190,6 +200,7 @@
             <geometry>
 		<cylinder length="0.096353" radius="0.01543"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -221,6 +232,7 @@
             <geometry>
                 <sphere radius="0.099452"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -247,6 +259,7 @@
             <geometry>
                 <cylinder length="0.15771" radius="0.028026"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -286,6 +299,7 @@
             <geometry>
                 <cylinder length="0.29147" radius="0.031846"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -318,6 +332,7 @@
             <geometry>
                 <cylinder length="0.24094" radius="0.021231"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -350,6 +365,7 @@
             <geometry>
                 <box size="0.12129     0.18194    0.042461"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -376,6 +392,7 @@
             <geometry>
                 <cylinder length="0.15771" radius="0.028026"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -415,6 +432,7 @@
             <geometry>
                 <cylinder length="0.29147" radius="0.031846"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -447,6 +465,7 @@
             <geometry>
                 <cylinder length="0.24094" radius="0.021231"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -479,6 +498,7 @@
             <geometry>
                 <box size="0.12129     0.18194    0.042461"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -519,6 +539,7 @@
             <geometry>
                 <cylinder length="0.52609" radius="0.066238"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -551,6 +572,7 @@
             <geometry>
                 <cylinder length="0.41228" radius="0.03813"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -590,6 +612,7 @@
             <geometry>
                 <box size="0.20791     0.07626    0.081257"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -615,6 +638,7 @@
             <geometry>
                 <box size="0.082089     0.07626    0.018102"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -654,6 +678,7 @@
             <geometry>
                 <cylinder length="0.52609" radius="0.066238"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -686,6 +711,7 @@
             <geometry>
 		<cylinder length="0.41228" radius="0.03813"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -725,6 +751,7 @@
             <geometry>
                 <box size="0.20791     0.07626    0.081257"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -750,6 +777,7 @@
             <geometry>
                 <box size="0.082089     0.07626    0.018102"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject06/humanSubject06_66dof.urdf
+++ b/humanSubject06/humanSubject06_66dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 66 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.16655     0.30753      0.1127"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -58,6 +64,7 @@
             <geometry>
                 <box size="0.16655     0.19678    0.089762"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -96,6 +103,7 @@
             <geometry>
                 <box size="0.16655     0.19678    0.081071"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -134,6 +142,7 @@
             <geometry>
                 <box size="0.16655     0.19678    0.081071"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -172,6 +181,7 @@
             <geometry>
                 <box size="0.13852    0.059426     0.11612"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -211,6 +221,7 @@
             <geometry>
 		<cylinder length="0.096353" radius="0.01543"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -249,6 +260,7 @@
             <geometry>
                 <sphere radius="0.099452"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -289,6 +301,7 @@
             <geometry>
                 <cylinder length="0.15771" radius="0.028026"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -328,6 +341,7 @@
             <geometry>
                 <cylinder length="0.29147" radius="0.031846"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -367,6 +381,7 @@
             <geometry>
                 <cylinder length="0.24094" radius="0.021231"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -406,6 +421,7 @@
             <geometry>
                 <box size="0.12129     0.18194    0.042461"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -446,6 +462,7 @@
             <geometry>
                 <cylinder length="0.15771" radius="0.028026"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -485,6 +502,7 @@
             <geometry>
                 <cylinder length="0.29147" radius="0.031846"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -524,6 +542,7 @@
             <geometry>
                 <cylinder length="0.24094" radius="0.021231"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -563,6 +582,7 @@
             <geometry>
                 <box size="0.12129     0.18194    0.042461"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -603,6 +623,7 @@
             <geometry>
                 <cylinder length="0.52609" radius="0.066238"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -642,6 +663,7 @@
             <geometry>
                 <cylinder length="0.41228" radius="0.03813"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -681,6 +703,7 @@
             <geometry>
                 <box size="0.20791     0.07626    0.081257"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -720,6 +743,7 @@
             <geometry>
                 <box size="0.082089     0.07626    0.018102"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -759,6 +783,7 @@
             <geometry>
                 <cylinder length="0.52609" radius="0.066238"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -798,6 +823,7 @@
             <geometry>
 		<cylinder length="0.41228" radius="0.03813"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -837,6 +863,7 @@
             <geometry>
                 <box size="0.20791     0.07626    0.081257"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -876,6 +903,7 @@
             <geometry>
                 <box size="0.082089     0.07626    0.018102"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject07/humanSubject07_48dof.urdf
+++ b/humanSubject07/humanSubject07_48dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 48 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.16203     0.29786     0.10818"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -51,6 +57,7 @@
             <geometry>
                 <box size="0.16203     0.19144    0.088486"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -82,6 +89,7 @@
             <geometry>
                 <box size="0.16203     0.19144    0.079914"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -113,6 +121,7 @@
             <geometry>
                 <box size="0.16203     0.19144    0.079914"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -151,6 +160,7 @@
             <geometry>
                 <box size="0.13899      0.0604     0.11489"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -190,6 +200,7 @@
             <geometry>
 		<cylinder length="0.09175" radius="0.015066"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -221,6 +232,7 @@
             <geometry>
                 <sphere radius="0.092703"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -247,6 +259,7 @@
             <geometry>
                 <cylinder length="0.16319" radius="0.02877"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -286,6 +299,7 @@
             <geometry>
                 <cylinder length="0.31509" radius="0.034205"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -318,6 +332,7 @@
             <geometry>
                 <cylinder length="0.2584" radius="0.022803"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -350,6 +365,7 @@
             <geometry>
                 <box size="0.12916     0.19374    0.045607"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -376,6 +392,7 @@
             <geometry>
                 <cylinder length="0.16319" radius="0.02877"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -415,6 +432,7 @@
             <geometry>
                 <cylinder length="0.31509" radius="0.034205"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -447,6 +465,7 @@
             <geometry>
                 <cylinder length="0.2584" radius="0.022803"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -479,6 +498,7 @@
             <geometry>
                 <box size="0.12916     0.19374    0.045607"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -519,6 +539,7 @@
             <geometry>
                 <cylinder length="0.51641" radius="0.065141"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -551,6 +572,7 @@
             <geometry>
                 <cylinder length="0.44136" radius="0.04069"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -590,6 +612,7 @@
             <geometry>
                 <box size="0.201     0.08138     0.07946"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -615,6 +638,7 @@
             <geometry>
                 <box size="0.078995     0.08138    0.017721"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -654,6 +678,7 @@
             <geometry>
                 <cylinder length="0.51641" radius="0.065141"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -686,6 +711,7 @@
             <geometry>
 		<cylinder length="0.44136" radius="0.04069"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -725,6 +751,7 @@
             <geometry>
                 <box size="0.201     0.08138     0.07946"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -750,6 +777,7 @@
             <geometry>
                 <box size="0.078995     0.08138    0.017721"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject07/humanSubject07_66dof.urdf
+++ b/humanSubject07/humanSubject07_66dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 66 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.16203     0.29786     0.10818"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -58,6 +64,7 @@
             <geometry>
                 <box size="0.16203     0.19144    0.088486"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -96,6 +103,7 @@
             <geometry>
                 <box size="0.16203     0.19144    0.079914"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -134,6 +142,7 @@
             <geometry>
                 <box size="0.16203     0.19144    0.079914"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -172,6 +181,7 @@
             <geometry>
                 <box size="0.13899      0.0604     0.11489"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -211,6 +221,7 @@
             <geometry>
 		<cylinder length="0.09175" radius="0.015066"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -249,6 +260,7 @@
             <geometry>
                 <sphere radius="0.092703"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -289,6 +301,7 @@
             <geometry>
                 <cylinder length="0.16319" radius="0.02877"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -328,6 +341,7 @@
             <geometry>
                 <cylinder length="0.31509" radius="0.034205"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -367,6 +381,7 @@
             <geometry>
                 <cylinder length="0.2584" radius="0.022803"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -406,6 +421,7 @@
             <geometry>
                 <box size="0.12916     0.19374    0.045607"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -446,6 +462,7 @@
             <geometry>
                 <cylinder length="0.16319" radius="0.02877"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -485,6 +502,7 @@
             <geometry>
                 <cylinder length="0.31509" radius="0.034205"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -524,6 +542,7 @@
             <geometry>
                 <cylinder length="0.2584" radius="0.022803"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -563,6 +582,7 @@
             <geometry>
                 <box size="0.12916     0.19374    0.045607"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -603,6 +623,7 @@
             <geometry>
                 <cylinder length="0.51641" radius="0.065141"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -642,6 +663,7 @@
             <geometry>
                 <cylinder length="0.44136" radius="0.04069"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -681,6 +703,7 @@
             <geometry>
                 <box size="0.201     0.08138     0.07946"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -720,6 +743,7 @@
             <geometry>
                 <box size="0.078995     0.08138    0.017721"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -759,6 +783,7 @@
             <geometry>
                 <cylinder length="0.51641" radius="0.065141"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -798,6 +823,7 @@
             <geometry>
 		<cylinder length="0.44136" radius="0.04069"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -837,6 +863,7 @@
             <geometry>
                 <box size="0.201     0.08138     0.07946"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -876,6 +903,7 @@
             <geometry>
                 <box size="0.078995     0.08138    0.017721"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject08/humanSubject08_48dof.urdf
+++ b/humanSubject08/humanSubject08_48dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 48 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.15204     0.27824     0.10627"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -51,6 +57,7 @@
             <geometry>
                 <box size="0.15204     0.17964     0.09309"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -82,6 +89,7 @@
             <geometry>
                 <box size="0.15204     0.17964    0.084092"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -113,6 +121,7 @@
             <geometry>
                 <box size="0.15204     0.17964    0.084092"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -151,6 +160,7 @@
             <geometry>
                 <box size="0.13473    0.054172     0.11815"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -190,6 +200,7 @@
             <geometry>
 		<cylinder length="0.086551" radius="0.014011"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -221,6 +232,7 @@
             <geometry>
                 <sphere radius="0.085351"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -247,6 +259,7 @@
             <geometry>
                 <cylinder length="0.1369" radius="0.024521"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -286,6 +299,7 @@
             <geometry>
                 <cylinder length="0.28194" radius="0.030664"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -318,6 +332,7 @@
             <geometry>
                 <cylinder length="0.23152" radius="0.020443"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -350,6 +365,7 @@
             <geometry>
                 <box size="0.11564     0.17345    0.040885"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -376,6 +392,7 @@
             <geometry>
                 <cylinder length="0.1369" radius="0.024521"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -415,6 +432,7 @@
             <geometry>
                 <cylinder length="0.28194" radius="0.030664"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -447,6 +465,7 @@
             <geometry>
                 <cylinder length="0.23152" radius="0.020443"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -479,6 +498,7 @@
             <geometry>
                 <box size="0.11564     0.17345    0.040885"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -519,6 +539,7 @@
             <geometry>
                 <cylinder length="0.47078" radius="0.059228"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -551,6 +572,7 @@
             <geometry>
                 <cylinder length="0.37257" radius="0.034524"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -590,6 +612,7 @@
             <geometry>
                 <box size="0.18527    0.069048    0.078737"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -615,6 +638,7 @@
             <geometry>
                 <box size="0.064729    0.069048    0.014986"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -654,6 +678,7 @@
             <geometry>
                 <cylinder length="0.47078" radius="0.059228"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -686,6 +711,7 @@
             <geometry>
 		<cylinder length="0.37257" radius="0.034524"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -725,6 +751,7 @@
             <geometry>
                 <box size="0.18527    0.069048    0.078737"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -750,6 +777,7 @@
             <geometry>
                 <box size="0.064729    0.069048    0.014986"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>

--- a/humanSubject08/humanSubject08_66dof.urdf
+++ b/humanSubject08/humanSubject08_66dof.urdf
@@ -1,6 +1,11 @@
 <!--URDF MODEL 48 DoFs-->
 
 <robot name="XSensStyleModel_template">
+
+<material name="color">
+    <color rgba="0.1 0.1 0.1 1"/>
+</material>
+
 <!--To open this model with Gazebo replace the null masses, inertias and dimensions of the 'fake links f1 and f2'-->
     <!--LINKS-->
 	<!--Link base (1)-->
@@ -18,6 +23,7 @@
             <geometry>
                 <box size="0.15204     0.27824     0.10627"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -51,6 +57,7 @@
             <geometry>
                 <box size="0.15204     0.17964     0.09309"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -82,6 +89,7 @@
             <geometry>
                 <box size="0.15204     0.17964    0.084092"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -113,6 +121,7 @@
             <geometry>
                 <box size="0.15204     0.17964    0.084092"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -151,6 +160,7 @@
             <geometry>
                 <box size="0.13473    0.054172     0.11815"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -190,6 +200,7 @@
             <geometry>
 		<cylinder length="0.086551" radius="0.014011"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -221,6 +232,7 @@
             <geometry>
                 <sphere radius="0.085351"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -247,6 +259,7 @@
             <geometry>
                 <cylinder length="0.1369" radius="0.024521"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -286,6 +299,7 @@
             <geometry>
                 <cylinder length="0.28194" radius="0.030664"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -318,6 +332,7 @@
             <geometry>
                 <cylinder length="0.23152" radius="0.020443"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -350,6 +365,7 @@
             <geometry>
                 <box size="0.11564     0.17345    0.040885"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -376,6 +392,7 @@
             <geometry>
                 <cylinder length="0.1369" radius="0.024521"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -415,6 +432,7 @@
             <geometry>
                 <cylinder length="0.28194" radius="0.030664"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -447,6 +465,7 @@
             <geometry>
                 <cylinder length="0.23152" radius="0.020443"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -479,6 +498,7 @@
             <geometry>
                 <box size="0.11564     0.17345    0.040885"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -519,6 +539,7 @@
             <geometry>
                 <cylinder length="0.47078" radius="0.059228"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -551,6 +572,7 @@
             <geometry>
                 <cylinder length="0.37257" radius="0.034524"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -590,6 +612,7 @@
             <geometry>
                 <box size="0.18527    0.069048    0.078737"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -615,6 +638,7 @@
             <geometry>
                 <box size="0.064729    0.069048    0.014986"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -654,6 +678,7 @@
             <geometry>
                 <cylinder length="0.47078" radius="0.059228"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -686,6 +711,7 @@
             <geometry>
 		<cylinder length="0.37257" radius="0.034524"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -725,6 +751,7 @@
             <geometry>
                 <box size="0.18527    0.069048    0.078737"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>
@@ -750,6 +777,7 @@
             <geometry>
                 <box size="0.064729    0.069048    0.014986"/>
             </geometry>
+            <material name="color"/>
         </visual>
 
         <collision>


### PR DESCRIPTION
This patch adds a material element to the link visuals, and sets the link color to gray. 
This change is to enable the visualization in https://github.com/robotology/human-dynamics-estimation/pull/242

CC @claudia-lat @lrapetti  