### PR TITLE
Fix hip pitch joint limit

### DIFF
--- a/humanSubject01/humanSubject01_48dof.urdf
+++ b/humanSubject01/humanSubject01_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject01/humanSubject01_48dof.urdf
+++ b/humanSubject01/humanSubject01_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject02/humanSubject02_48dof.urdf
+++ b/humanSubject02/humanSubject02_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject02/humanSubject02_48dof.urdf
+++ b/humanSubject02/humanSubject02_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject03/humanSubject03_48dof.urdf
+++ b/humanSubject03/humanSubject03_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject03/humanSubject03_48dof.urdf
+++ b/humanSubject03/humanSubject03_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject04/humanSubject04_48dof.urdf
+++ b/humanSubject04/humanSubject04_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject04/humanSubject04_48dof.urdf
+++ b/humanSubject04/humanSubject04_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject05/humanSubject05_48dof.urdf
+++ b/humanSubject05/humanSubject05_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject05/humanSubject05_48dof.urdf
+++ b/humanSubject05/humanSubject05_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject06/humanSubject06_48dof.urdf
+++ b/humanSubject06/humanSubject06_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject06/humanSubject06_48dof.urdf
+++ b/humanSubject06/humanSubject06_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject07/humanSubject07_48dof.urdf
+++ b/humanSubject07/humanSubject07_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject07/humanSubject07_48dof.urdf
+++ b/humanSubject07/humanSubject07_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject08/humanSubject08_48dof.urdf
+++ b/humanSubject08/humanSubject08_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject08/humanSubject08_48dof.urdf
+++ b/humanSubject08/humanSubject08_48dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject08/humanSubject08_66dof.urdf
+++ b/humanSubject08/humanSubject08_66dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
+        <limit effort="30" velocity="1.0" lower="-2.0944" upper="0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">

--- a/humanSubject08/humanSubject08_66dof.urdf
+++ b/humanSubject08/humanSubject08_66dof.urdf
@@ -1048,7 +1048,7 @@
         <parent link="RightUpperLeg_f1"/>
         <child link="RightUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jRightHip_rotz" type="revolute">
@@ -1121,7 +1121,7 @@
         <parent link="LeftUpperLeg_f1"/>
         <child link="LeftUpperLeg_f2"/>
         <dynamics damping="0.1" friction="0.0"/>
-        <limit effort="30" velocity="1.0" lower="-0.261799" upper="2.0944" />
+        <limit effort="30" velocity="1.0" lower="2.0944" upper="-0.261799" />
         <axis xyz="0 1 0" />
     </joint>
     <joint name="jLeftHip_rotz" type="revolute">


### PR DESCRIPTION
The forward and backword joint limit of the hip pitch seemed to be exchanged (this is causing also what observed by @kouroshD in https://github.com/robotology/human-gazebo/issues/21).

This PR should be fixing it

cc @riccardoGrieco